### PR TITLE
corrected typo

### DIFF
--- a/documentation/utilities/component-registration.md
+++ b/documentation/utilities/component-registration.md
@@ -43,7 +43,7 @@ ArrayRegistry.Add<Inventory>();
 These two things do **exactly** the **same thing**, but are slightly less boilerplate code and automatically determine the **code size**.
 {% endhint %}
 
-## Acessing components
+## Accessing components
 
 You can not only register components but also receive, replace and remove.
 


### PR DESCRIPTION
This pull request includes a small change to the `documentation/utilities/component-registration.md` file. The change corrects a typo in the section header from "Acessing components" to "Accessing components".