### PR TITLE
Fixed incorrect PURE_ECS entity size (4 bytes → 8 bytes)

### DIFF
--- a/documentation/optimizations/pure_ecs.md
+++ b/documentation/optimizations/pure_ecs.md
@@ -6,7 +6,7 @@ description: PURE_ECS, making your entities even slimmer and faster.
 
 Entities contain some meta data by default to make it easier for you as a developer. If you leave them out, however, you can still squeeze out some performance.
 
-This is where `PURE_ECS` comes into play. This is a way of reducing the empty size of each [**entity**](../entity.md) to just **4 bytes**! **The way to make your** [**world**](../world.md) **even more efficient!** This means that even more entities fit into each individual chunk, which means that your **queries** **process** the **entities** even **more efficiently**. All entity operations speed up automatically. You want to bring millions of entities into battle? You can!
+This is where `PURE_ECS` comes into play. This is a way of reducing the empty size of each [**entity**](../entity.md) to just **8 bytes**! **The way to make your** [**world**](../world.md) **even more efficient!** This means that even more entities fit into each individual chunk, which means that your **queries** **process** the **entities** even **more efficiently**. All entity operations speed up automatically. You want to bring millions of entities into battle? You can!
 
 ## Setup
 


### PR DESCRIPTION
### Problem

The PURE_ECS documentation states:

> This is a way of reducing the empty size of each entity to just **4 bytes**!

This is incorrect. Looking at the source code, the `Entity` struct under `PURE_ECS` still has two `int` fields:

```csharp
public readonly int Id;       // 4 bytes
public readonly int Version;  // 4 bytes
```

Only `WorldId` is removed. The actual size is **8 bytes** (down from 12 bytes), not 4 bytes.

### Fix

Changed "4 bytes" → "8 bytes" in `pure-ecs.md`.